### PR TITLE
[NO-ISSUE] Use windbreaker-hooks db, use consolidated 'migrations' config

### DIFF
--- a/config/docker.yml
+++ b/config/docker.yml
@@ -12,3 +12,5 @@ knex:
     password: 'postgres'
     database: 'windbreaker'
   debug: true
+  migrations:
+    tableName: 'migrations'

--- a/config/docker.yml
+++ b/config/docker.yml
@@ -10,7 +10,7 @@ knex:
     host: 'postgres'
     user: 'postgres'
     password: 'postgres'
-    database: 'windbreaker'
+    database: 'windbreaker-hooks'
   debug: true
   migrations:
     tableName: 'migrations'

--- a/config/localhost.yml
+++ b/config/localhost.yml
@@ -12,3 +12,5 @@ knex:
     password: 'postgres'
     database: 'windbreaker'
   debug: true
+  migrations:
+    tableName: 'migrations'

--- a/config/localhost.yml
+++ b/config/localhost.yml
@@ -10,7 +10,7 @@ knex:
     host: 'postgres'
     user: 'postgres'
     password: 'postgres'
-    database: 'windbreaker'
+    database: 'windbreaker-hooks'
   debug: true
   migrations:
     tableName: 'migrations'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     environment:
       POSTGRES_USER: 'postgres'
       POSTGRES_PASSWORD: 'postgres'
-      POSTGRES_DB: 'windbreaker'
+      POSTGRES_DB: 'windbreaker-hooks'
     ports:
       - 5432
   rabbitmq:

--- a/src/dao/index.js
+++ b/src/dao/index.js
@@ -18,7 +18,7 @@ exports.createDao = function () {
 exports.migrate = async function () {
   logger.info('Attempting to run database migrations...')
   return daoHelper.getKnex().migrate.latest({
-    tableName: config.getWebhookMigrationsTableName(),
+    tableName: config.getKnex().migrations.tableName,
     directory: path.join(__dirname, 'migrations')
   })
 }

--- a/src/dao/index.js
+++ b/src/dao/index.js
@@ -18,7 +18,7 @@ exports.createDao = function () {
 exports.migrate = async function () {
   logger.info('Attempting to run database migrations...')
   return daoHelper.getKnex().migrate.latest({
-    tableName: config.getKnex().migrations.tableName,
+    tableName: config.getKnex().data.migrations.tableName,
     directory: path.join(__dirname, 'migrations')
   })
 }

--- a/src/dao/knexfile.js
+++ b/src/dao/knexfile.js
@@ -6,10 +6,6 @@ config.load()
 const environment = config.getEnvironment().name().toLowerCase()
 
 let exported = {}
-exported[environment] = Object.assign(config.getKnex().clean(), {
-  migrations: {
-    tableName: config.getWebhookMigrationsTableName()
-  }
-})
+exported[environment] = config.getKnex().clean()
 
 module.exports = exported

--- a/src/models/HooksServiceConfig.js
+++ b/src/models/HooksServiceConfig.js
@@ -17,10 +17,6 @@ module.exports = BaseConfig.extend({
       default: 'amqp://127.0.0.1:5672'
     },
     knex: KnexConfig,
-    webhookMigrationsTableName: {
-      description: 'The database table name for running migrations',
-      default: 'webhook_migrations'
-    },
     redisClusterNodes: [RedisClusterNodeConfig],
     webhookEventsQueueName: {
       description: 'The name of the queue in which webhook events are published on',


### PR DESCRIPTION
Uses new config from windbreaker-io/windbreaker-service-util#33. Though, this is mostly for completeness/verbosity purposes since knex uses 'migrations' by default anyway.